### PR TITLE
Get markers back on map

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootstrap-sass', '~> 3.2.0'
 gem 'autoprefixer-rails'
 gem 'omniauth-facebook'
 gem 'figaro'
+gem 'responders', '~> 2.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,8 @@ GEM
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
+    responders (2.1.0)
+      railties (>= 4.2.0, < 5)
     sass (3.4.13)
     sass-rails (5.0.1)
       railties (>= 4.0.0, < 5.0)
@@ -261,6 +263,7 @@ DEPENDENCIES
   pry
   rails (= 4.2.0)
   rails_12factor
+  responders (~> 2.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   shoulda

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -2,7 +2,7 @@ var map;
 
 function initialize() {
   var mapOptions = {
-    zoom: 10
+    zoom: 13
   };
   map = new google.maps.Map(document.getElementById('map-canvas'),
   mapOptions);
@@ -13,12 +13,6 @@ function initialize() {
       var pos = new google.maps.LatLng(position.coords.latitude,
         position.coords.longitude);
 
-        var infowindow = new google.maps.InfoWindow({
-          map: map,
-          position: pos,
-          content: 'Location found using HTML5.'
-        });
-
         map.setCenter(pos);
       }, function() {
         handleNoGeolocation(true);
@@ -27,6 +21,24 @@ function initialize() {
       // Browser doesn't support Geolocation
       handleNoGeolocation(false);
     }
+
+
+    // need the lat long for each restaurant
+    $.get('restaurants.json', function(restaurantData) {
+      restaurantData.forEach(function(restaurant) {
+        // make a new LatLng object
+        var latlng = new google.maps.LatLng(restaurant.latitude, restaurant.longitude);
+        // make a new Marker object
+        var marker = new google.maps.Marker({
+          position: latlng,
+          map: map,
+          title:"Hello World!"
+        });
+        // place the marker on the map
+        marker.setMap(map);
+      });
+    });
+
   }
 
   function handleNoGeolocation(errorFlag) {
@@ -42,7 +54,6 @@ function initialize() {
       content: content
     };
 
-    var infowindow = new google.maps.InfoWindow(options);
     map.setCenter(options.position);
   }
 

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,9 +1,17 @@
 class RestaurantsController < ApplicationController
+  respond_to :html, :json
+
+  after_filter do
+    puts response.body
+  end
+
   def show
     @restaurant = Restaurant.find(params[:id])
+
   end
 
   def index
     @restaurants = Restaurant.kid_type(params[:format])
+    respond_with @restaurants
   end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -11,7 +11,7 @@ class RestaurantsController < ApplicationController
   end
 
   def index
-    @restaurants = Restaurant.kid_type(params[:format])
+    @restaurants = Restaurant.kid_friendly?(params[:kid_friendly])
     respond_with @restaurants
   end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -2,11 +2,9 @@ class Restaurant < ActiveRecord::Base
   validates :name, :longitude, :latitude, :address, :locality,
             :region, :postcode, :phone_number, presence: true
 
-  def self.kid_type(type)
-    if type == "kids"
-      @restaurants = where(kid_friendly: true)
-    elsif type == "no-kids"
-      @restaurants = where(kid_friendly: false)
+  def self.kid_friendly?(query)
+    if query
+      @restaurants = where(kid_friendly: query)
     else
       @restaurants = all
     end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,9 +4,9 @@
 
       <%= image_tag("sushi.png", class: "food-baby") %>
 
-      <%= link_to "Eat with Kids", restaurants_path("kids"), class: "btn btn-lg btn-default mobile-btn" %>
+      <%= link_to "Eat with Kids", restaurants_path(:kid_friendly => "true"), class: "btn btn-lg btn-default mobile-btn" %>
 
-      <%= link_to "Eat without Kids", restaurants_path("no-kids"), class: "btn btn-lg btn-default mobile-btn" %>
+      <%= link_to "Eat without Kids", restaurants_path(:kid_friendly => "false"), class: "btn btn-lg btn-default mobile-btn" %>
 
       <form>
         <div class="input-group search">


### PR DESCRIPTION
After getting rid of the gmaps4rails gem and adding the google api javascript in, the markers went away. This merge adds them back and also fixes a query from the welcome page that sorts restaurants by kid-friendliness.
